### PR TITLE
Site: Papers catalog + nav update (v2, clean rebase)

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@ footer .copyright{font-size:.7rem;color:#6B7280;margin-top:1rem}
 <a href="#evidence">Evidence</a>
 <a href="#artifacts">Artifacts</a>
 <a href="#publications">Publications</a>
+<a href="papers/">Catalog</a>
 <a href="#evidence-deck">Charts</a>
 <a href="#roadmap">Roadmap</a>
 <a href="#genealogy">Genealogy</a>
@@ -291,7 +292,7 @@ x.fillStyle="#818CF8";x.fillRect(W-90,8,12,12);x.fillText("Transformer",W-74,18)
 
 <section id="publications">
 <h2>Publications</h2>
-<p style="color:#9CA3AF;margin-bottom:2rem">All papers open-access on Zenodo with registered DOIs. Full archive at <a href="https://zenodo.org/communities/qwav/" style="color:#818CF8">zenodo.org/communities/qwav/</a> (145+ records). <strong>GitHub-native archive:</strong> <a href="https://github.com/QNFO/research-publications" style="color:#FBBF24">QNFO/research-publications →</a> (564 markdown papers, browsable on GitHub with auto-PDF generation). <strong>Searchable catalog:</strong> <a href="https://qnfo.github.io/ultrametric-tree-universality/pub-hub.html" style="color:#FBBF24">Publication Hub â†’</a> (35 publications, filter by domain, level, DOI)</p>
+<p style="color:#9CA3AF;margin-bottom:2rem">All papers open-access on Zenodo with registered DOIs. <strong>Full catalog:</strong> <a href="papers/" style="color:#FBBF24">45 papers on GitHub</a> | Also on <a href="https://zenodo.org/communities/qwav/" style="color:#818CF8">Zenodo</a> (145+ records).
 <table class="pub-table">
 <thead><tr><th>Title</th><th>Date</th><th>DOI</th><th>Code</th></tr></thead>
 <tbody>

--- a/site/papers/index.html
+++ b/site/papers/index.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>QWAV Publications Catalog</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:#0A1128;color:#E5E5E5;font-family:system-ui,-apple-system,sans-serif;line-height:1.6}
+nav{position:sticky;top:0;z-index:50;background:rgba(10,17,40,0.95);backdrop-filter:blur(12px);border-bottom:1px solid rgba(129,140,248,0.15);padding:1rem 2rem;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:.5rem}
+nav a{color:#818CF8;text-decoration:none;font-size:.85rem;transition:color .2s}
+nav a:hover{color:#A5B4FC}
+.nav-brand{font-weight:700;font-size:1rem;background:linear-gradient(135deg,#818CF8,#C4B5FD);-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.nav-links{display:flex;gap:1.5rem;flex-wrap:wrap}
+section{padding:4rem 2rem;max-width:1100px;margin:0 auto;width:100%}
+h1{font-size:2rem;margin-bottom:1rem;background:linear-gradient(135deg,#818CF8,#C4B5FD);-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.paper-list{display:flex;flex-direction:column;gap:0.5rem}
+.paper-row{display:flex;justify-content:space-between;align-items:center;padding:0.75rem 1rem;background:rgba(129,140,248,0.05);border-radius:8px;transition:background .2s;flex-wrap:wrap;gap:0.5rem}
+.paper-row:hover{background:rgba(129,140,248,0.12)}
+.paper-title{flex:1;min-width:200px}
+.paper-title a{color:#E5E5E5;text-decoration:none}
+.paper-title a:hover{color:#818CF8}
+.paper-meta{font-size:0.75rem;color:#94A3B8;white-space:nowrap}
+.paper-links{display:flex;gap:0.75rem}
+.paper-links a{font-size:0.75rem;color:#818CF8;text-decoration:none;padding:0.25rem 0.5rem;border:1px solid rgba(129,140,248,0.3);border-radius:4px;transition:all .2s}
+.paper-links a:hover{background:rgba(129,140,248,0.15);border-color:#818CF8}
+footer{padding:2rem;text-align:center;color:#64748B;font-size:.8rem;border-top:1px solid rgba(129,140,248,0.1);margin-top:2rem}
+footer a{color:#818CF8}
+.count-badge{background:rgba(129,140,248,0.15);color:#A5B4FC;padding:0.2rem 0.6rem;border-radius:12px;font-size:0.8rem}
+</style>
+</head>
+<body>
+<nav>
+<a href="/QWAV/" class="nav-brand">QWAV</a>
+<div class="nav-links">
+<a href="/QWAV/">Home</a>
+<a href="/QWAV/papers/">Papers</a>
+<a href="https://github.com/QNFO/QWAV">GitHub</a>
+<a href="https://github.com/QNFO/QWAV/wiki">Wiki</a>
+</div>
+</nav>
+
+<section>
+<h1>Publications Catalog <span class="count-badge">45 papers</span></h1>
+<p style="color:#94A3B8;margin-bottom:2rem">All QWAV publications in one place. Click a title to read on GitHub, or download the raw markdown. Papers are also available on <a href="https://zenodo.org/search?q=qwav" style="color:#818CF8">Zenodo</a>.</p>
+
+<div class="paper-list">
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/A%20Different%20Geometry%20for%20Computing.md">A Different Geometry for Computing</a></div>
+    <div class="paper-meta">72,683 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/A%20Different%20Geometry%20for%20Computing.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/A%20Different%20Geometry%20for%20Computing.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20Project.md">Adelic Constraints Project</a></div>
+    <div class="paper-meta">96,891 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20Project.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Adelic%20Constraints%20Project.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%201.md">Adelic Constraints on Quantum Field Theory Phase 1</a></div>
+    <div class="paper-meta">54,577 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%201.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%201.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%202.md">Adelic Constraints on Quantum Field Theory Phase 2</a></div>
+    <div class="paper-meta">18,819 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%202.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%202.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%203.md">Adelic Constraints on Quantum Field Theory Phase 3</a></div>
+    <div class="paper-meta">28,416 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%203.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Adelic%20Constraints%20on%20Quantum%20Field%20Theory%20Phase%203.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Geometry%20and%20the%20Architecture%20of%20Factorization.md">Adelic Geometry and the Architecture of Factorization</a></div>
+    <div class="paper-meta">111,032 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Adelic%20Geometry%20and%20the%20Architecture%20of%20Factorization.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Adelic%20Geometry%20and%20the%20Architecture%20of%20Factorization.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/An%20Introvert's%20Deep-Tech%20Startup%20Path.md">An Introvert's Deep-Tech Startup Path</a></div>
+    <div class="paper-meta">26,041 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/An%20Introvert's%20Deep-Tech%20Startup%20Path.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/An%20Introvert's%20Deep-Tech%20Startup%20Path.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Arithmetic%20Gauge.md">Arithmetic Gauge</a></div>
+    <div class="paper-meta">21,311 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Arithmetic%20Gauge.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Arithmetic%20Gauge.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Bruhat-Tits%20Quantum%20Processor.md">Bruhat-Tits Quantum Processor</a></div>
+    <div class="paper-meta">31,554 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Bruhat-Tits%20Quantum%20Processor.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Bruhat-Tits%20Quantum%20Processor.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Bruhat–Tits%20Geometry%20of%20Scale.md">Bruhat–Tits Geometry of Scale</a></div>
+    <div class="paper-meta">76,252 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Bruhat–Tits%20Geometry%20of%20Scale.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Bruhat–Tits%20Geometry%20of%20Scale.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Bruhat–Tits%20Tree%20as%20a%20Unifying%20Geometric%20Object.md">Bruhat–Tits Tree as a Unifying Geometric Object</a></div>
+    <div class="paper-meta">204,639 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Bruhat–Tits%20Tree%20as%20a%20Unifying%20Geometric%20Object.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Bruhat–Tits%20Tree%20as%20a%20Unifying%20Geometric%20Object.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Convergence%20Consilience%20and%20the%20Hierarchical%20Architecture%20of%20Reality.md">Convergence Consilience and the Hierarchical Architecture of Reality</a></div>
+    <div class="paper-meta">45,911 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Convergence%20Consilience%20and%20the%20Hierarchical%20Architecture%20of%20Reality.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Convergence%20Consilience%20and%20the%20Hierarchical%20Architecture%20of%20Reality.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Every%20Point%20is%20the%20Center%20of%20its%20Own%20Universe.md">Every Point is the Center of its Own Universe</a></div>
+    <div class="paper-meta">55,255 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Every%20Point%20is%20the%20Center%20of%20its%20Own%20Universe.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Every%20Point%20is%20the%20Center%20of%20its%20Own%20Universe.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Everything%20Is%20Divisible.md">Everything Is Divisible</a></div>
+    <div class="paper-meta">170,546 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Everything%20Is%20Divisible.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Everything%20Is%20Divisible.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Few%20Become%20One%20—%20Polysynthetic%20Communication%20and%20the%20Ultrametric%20Architecture%20of%20Language.md">Few Become One — Polysynthetic Communication and the Ultrametric Architecture of Language</a></div>
+    <div class="paper-meta">71,527 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Few%20Become%20One%20—%20Polysynthetic%20Communication%20and%20the%20Ultrametric%20Architecture%20of%20Language.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Few%20Become%20One%20—%20Polysynthetic%20Communication%20and%20the%20Ultrametric%20Architecture%20of%20Language.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Fine-Structure%20Constant%20as%20a%20Cross-Ratio.md">Fine-Structure Constant as a Cross-Ratio</a></div>
+    <div class="paper-meta">49,921 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Fine-Structure%20Constant%20as%20a%20Cross-Ratio.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Fine-Structure%20Constant%20as%20a%20Cross-Ratio.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Force-Multiplier%20Playbook.md">Force-Multiplier Playbook</a></div>
+    <div class="paper-meta">18,141 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Force-Multiplier%20Playbook.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Force-Multiplier%20Playbook.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Hierarchical%20Geometry%20of%20Numbers.md">Hierarchical Geometry of Numbers</a></div>
+    <div class="paper-meta">52,331 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Hierarchical%20Geometry%20of%20Numbers.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Hierarchical%20Geometry%20of%20Numbers.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Hierarchical%20Universe.md">Hierarchical Universe</a></div>
+    <div class="paper-meta">174,226 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Hierarchical%20Universe.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Hierarchical%20Universe.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/How%20Geometry%20Creates%20Memory.md">How Geometry Creates Memory</a></div>
+    <div class="paper-meta">119,013 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/How%20Geometry%20Creates%20Memory.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/How%20Geometry%20Creates%20Memory.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Language%20as%20Information%20Architecture.md">Language as Information Architecture</a></div>
+    <div class="paper-meta">47,533 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Language%20as%20Information%20Architecture.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Language%20as%20Information%20Architecture.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Morita%20p-Adic%20Gamma%20Function.md">Morita p-Adic Gamma Function</a></div>
+    <div class="paper-meta">24,392 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Morita%20p-Adic%20Gamma%20Function.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Morita%20p-Adic%20Gamma%20Function.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/One%20Pattern.md">One Pattern</a></div>
+    <div class="paper-meta">36,001 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/One%20Pattern.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/One%20Pattern.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Q-PNA%20Research%20Specification%20v2.0.md">Q-PNA Research Specification v2.0</a></div>
+    <div class="paper-meta">50,094 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Q-PNA%20Research%20Specification%20v2.0.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Q-PNA%20Research%20Specification%20v2.0.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Quantum-Mechanical%20Physics%20as%20Invariant%20Geometric%20Structure.md">Quantum-Mechanical Physics as Invariant Geometric Structure</a></div>
+    <div class="paper-meta">52,470 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Quantum-Mechanical%20Physics%20as%20Invariant%20Geometric%20Structure.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Quantum-Mechanical%20Physics%20as%20Invariant%20Geometric%20Structure.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Road%20Not%20Taken.md">Road Not Taken</a></div>
+    <div class="paper-meta">19,476 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Road%20Not%20Taken.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Road%20Not%20Taken.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Signal%20and%20Worker%20—%20How%20Proteins%20Activate%20Electrons.md">Signal and Worker — How Proteins Activate Electrons</a></div>
+    <div class="paper-meta">29,754 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Signal%20and%20Worker%20—%20How%20Proteins%20Activate%20Electrons.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Signal%20and%20Worker%20—%20How%20Proteins%20Activate%20Electrons.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Statistical%20Genesis%20of%20Appearance.md">Statistical Genesis of Appearance</a></div>
+    <div class="paper-meta">45,204 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Statistical%20Genesis%20of%20Appearance.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Statistical%20Genesis%20of%20Appearance.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Symmetric%20Extension%20of%20Ultrametric%20Error%20Confinement.md">Symmetric Extension of Ultrametric Error Confinement</a></div>
+    <div class="paper-meta">37,042 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Symmetric%20Extension%20of%20Ultrametric%20Error%20Confinement.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Symmetric%20Extension%20of%20Ultrametric%20Error%20Confinement.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Symmetry%20as%20a%20Grammatical%20Function.md">Symmetry as a Grammatical Function</a></div>
+    <div class="paper-meta">82,753 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Symmetry%20as%20a%20Grammatical%20Function.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Symmetry%20as%20a%20Grammatical%20Function.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/TREE%20OF%20FREQUENCIES.md">TREE OF FREQUENCIES</a></div>
+    <div class="paper-meta">157,660 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/TREE%20OF%20FREQUENCIES.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/TREE%20OF%20FREQUENCIES.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Primordial%20Mark.md">The Primordial Mark</a></div>
+    <div class="paper-meta">37,540 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Primordial%20Mark.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/The%20Primordial%20Mark.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Tree%20Is%20Real%20—%20Computational%20Validation%20of%20Ultrametric%20Convergence.md">The Tree Is Real — Computational Validation of Ultrametric Convergence</a></div>
+    <div class="paper-meta">31,317 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Tree%20Is%20Real%20—%20Computational%20Validation%20of%20Ultrametric%20Convergence.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/The%20Tree%20Is%20Real%20—%20Computational%20Validation%20of%20Ultrametric%20Convergence.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Tree%20and%20Its%20Shadow%20-%20A%20Unified%20Phase%20Diagram%20of%20Ultrametric%20Organization%20and%20Resistance.md">The Tree and Its Shadow - A Unified Phase Diagram of Ultrametric Organization and Resistance</a></div>
+    <div class="paper-meta">31,000 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Tree%20and%20Its%20Shadow%20-%20A%20Unified%20Phase%20Diagram%20of%20Ultrametric%20Organization%20and%20Resistance.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/The%20Tree%20and%20Its%20Shadow%20-%20A%20Unified%20Phase%20Diagram%20of%20Ultrametric%20Organization%20and%20Resistance.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Tree%20at%20the%20Bottom%20of%20Thought%20—%20A%20Synthesis%20of%20Ultrametric%20Branching.md">The Tree at the Bottom of Thought — A Synthesis of Ultrametric Branching</a></div>
+    <div class="paper-meta">23,495 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/The%20Tree%20at%20the%20Bottom%20of%20Thought%20—%20A%20Synthesis%20of%20Ultrametric%20Branching.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/The%20Tree%20at%20the%20Bottom%20of%20Thought%20—%20A%20Synthesis%20of%20Ultrametric%20Branching.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Tree%20Distance%20Cophenetic.md">Tree Distance Cophenetic</a></div>
+    <div class="paper-meta">36,486 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Tree%20Distance%20Cophenetic.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Tree%20Distance%20Cophenetic.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Tree%20at%20the%20Bottom%20of%20Everything.md">Tree at the Bottom of Everything</a></div>
+    <div class="paper-meta">22,305 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Tree%20at%20the%20Bottom%20of%20Everything.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Tree%20at%20the%20Bottom%20of%20Everything.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Two%20Ways%20of%20Measuring.md">Two Ways of Measuring</a></div>
+    <div class="paper-meta">94,082 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Two%20Ways%20of%20Measuring.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Two%20Ways%20of%20Measuring.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Geometry%20as%20Common%20Structure.md">Ultrametric Geometry as Common Structure</a></div>
+    <div class="paper-meta">45,298 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Geometry%20as%20Common%20Structure.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Ultrametric%20Geometry%20as%20Common%20Structure.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Paradigm.md">Ultrametric Paradigm</a></div>
+    <div class="paper-meta">148,598 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Paradigm.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Ultrametric%20Paradigm.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Quantum%20Computation%20and%20the%20Langlands%20Program.md">Ultrametric Quantum Computation and the Langlands Program</a></div>
+    <div class="paper-meta">104,703 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Quantum%20Computation%20and%20the%20Langlands%20Program.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Ultrametric%20Quantum%20Computation%20and%20the%20Langlands%20Program.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Quantum%20Computation.md">Ultrametric Quantum Computation</a></div>
+    <div class="paper-meta">106,767 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Quantum%20Computation.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Ultrametric%20Quantum%20Computation.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Quantum%20Computing%20Foundations.md">Ultrametric Quantum Computing Foundations</a></div>
+    <div class="paper-meta">28,566 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Ultrametric%20Quantum%20Computing%20Foundations.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Ultrametric%20Quantum%20Computing%20Foundations.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/Validation%20of%20Ultrametric%20Error%20Confinement.md">Validation of Ultrametric Error Confinement</a></div>
+    <div class="paper-meta">30,457 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/Validation%20of%20Ultrametric%20Error%20Confinement.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/Validation%20of%20Ultrametric%20Error%20Confinement.md">Raw</a>
+    </div>
+</div>
+<div class="paper-row">
+    <div class="paper-title"><a href="https://github.com/QNFO/QWAV/blob/main/papers/When%20Proofs%20Deceive%20—%20A%20Taxonomy%20of%20Mathematical%20Certainty%20in%20Physics.md">When Proofs Deceive — A Taxonomy of Mathematical Certainty in Physics</a></div>
+    <div class="paper-meta">31,913 bytes</div>
+    <div class="paper-links">
+        <a href="https://github.com/QNFO/QWAV/blob/main/papers/When%20Proofs%20Deceive%20—%20A%20Taxonomy%20of%20Mathematical%20Certainty%20in%20Physics.md">Read</a>
+        <a href="https://raw.githubusercontent.com/QNFO/QWAV/main/papers/When%20Proofs%20Deceive%20—%20A%20Taxonomy%20of%20Mathematical%20Certainty%20in%20Physics.md">Raw</a>
+    </div>
+</div>
+</div>
+</section>
+
+<footer>
+<p>QWAV -- Ultrametric Quantum Computing &amp; AI | <a href="https://github.com/QNFO/QWAV">QNFO/QWAV</a> | <a href="https://qnfo.github.io/QWAV/">Main Site</a></p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
Adds papers catalog at /QWAV/papers/ listing all 45 publications. Updates main index.html nav and publications section.