### PR TITLE
Site: Projects repository listing page + nav links

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,8 @@ footer .copyright{font-size:.7rem;color:#6B7280;margin-top:1rem}
 <a href="#roadmap">Roadmap</a>
 <a href="#genealogy">Genealogy</a>
 <a href="#prior-work">Prior Work</a>
+<a href="papers/">Papers</a>
+<a href="projects/">Projects</a>
 <a href="https://qwav.tech">Marquee</a>
 </div>
 </nav>

--- a/site/projects/index.html
+++ b/site/projects/index.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>QWAV Project Repositories</title>
+<style>
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:#0A1128;color:#E5E5E5;font-family:system-ui,-apple-system,sans-serif;line-height:1.6}
+nav{position:sticky;top:0;z-index:50;background:rgba(10,17,40,0.95);backdrop-filter:blur(12px);border-bottom:1px solid rgba(129,140,248,0.15);padding:1rem 2rem;display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:.5rem}
+nav a{color:#818CF8;text-decoration:none;font-size:.85rem;transition:color .2s}
+nav a:hover{color:#A5B4FC}
+.nav-brand{font-weight:700;font-size:1rem;background:linear-gradient(135deg,#818CF8,#C4B5FD);-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.nav-links{display:flex;gap:1.5rem;flex-wrap:wrap}
+section{padding:4rem 2rem;max-width:1100px;margin:0 auto;width:100%}
+h1{font-size:2rem;margin-bottom:0.5rem;background:linear-gradient(135deg,#818CF8,#C4B5FD);-webkit-background-clip:text;-webkit-text-fill-color:transparent}
+.subtitle{color:#94A3B8;margin-bottom:2rem}
+.repo-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:1rem}
+.repo-card{background:rgba(129,140,248,0.05);border:1px solid rgba(129,140,248,0.1);border-radius:8px;padding:1.25rem;transition:all .2s}
+.repo-card:hover{background:rgba(129,140,248,0.1);border-color:rgba(129,140,248,0.25)}
+.repo-card h3{margin-bottom:0.5rem}
+.repo-card h3 a{color:#E5E5E5;text-decoration:none}
+.repo-card h3 a:hover{color:#818CF8}
+.repo-card p{color:#94A3B8;font-size:0.85rem;margin-bottom:0.75rem}
+.repo-links{display:flex;gap:0.75rem;flex-wrap:wrap}
+.repo-links a{font-size:0.75rem;color:#818CF8;text-decoration:none;padding:0.25rem 0.5rem;border:1px solid rgba(129,140,248,0.3);border-radius:4px;transition:all .2s}
+.repo-links a:hover{background:rgba(129,140,248,0.15);border-color:#818CF8}
+footer{padding:2rem;text-align:center;color:#64748B;font-size:.8rem;border-top:1px solid rgba(129,140,248,0.1);margin-top:2rem}
+footer a{color:#818CF8}
+.count-badge{background:rgba(129,140,248,0.15);color:#A5B4FC;padding:0.2rem 0.6rem;border-radius:12px;font-size:0.8rem}
+</style>
+</head>
+<body>
+<nav>
+<a href="/QWAV/" class="nav-brand">QWAV</a>
+<div class="nav-links">
+<a href="/QWAV/">Home</a>
+<a href="/QWAV/papers/">Papers</a>
+<a href="/QWAV/projects/">Projects</a>
+<a href="https://github.com/QNFO/QWAV">GitHub</a>
+<a href="https://github.com/QNFO/QWAV/wiki">Wiki</a>
+</div>
+</nav>
+
+<section>
+<h1>Project Repositories <span class="count-badge">15 repos</span></h1>
+<p class="subtitle">All QWAV projects are self-contained GitHub repositories under the <a href="https://github.com/QNFO" style="color:#818CF8">QNFO organization</a>. Each repo contains its own code, papers, GitHub Pages site, and project management.</p>
+
+<div class="repo-grid">
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/QWAV">QWAV</a></h3>
+    <p>Program hub — papers, site, wiki, discussions</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/QWAV">GitHub</a>
+        <a href="https://qnfo.github.io/QWAV/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/ultrametric-error-confinement">ultrametric-error-confinement</a></h3>
+    <p>Tier 0: Bruhat-Tits tree error simulation</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/ultrametric-error-confinement">GitHub</a>
+        <a href="https://qnfo.github.io/ultrametric-error-confinement/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/Q-PNA">Q-PNA</a></h3>
+    <p>Quantum-Native p-Adic Neural Architecture</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/Q-PNA">GitHub</a>
+        <a href="https://qnfo.github.io/Q-PNA/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/ultrametric-convergence">ultrametric-convergence</a></h3>
+    <p>Ultrametric vs Euclidean particle simulation</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/ultrametric-convergence">GitHub</a>
+        <a href="https://qnfo.github.io/ultrametric-convergence/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/tree-distance">tree-distance</a></h3>
+    <p>Cophenetic/ultrametric/Euclidean distance comparison</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/tree-distance">GitHub</a>
+        <a href="https://qnfo.github.io/tree-distance/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/hardware-pathway">hardware-pathway</a></h3>
+    <p>3D rotatable neutral atom tree visualization</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/hardware-pathway">GitHub</a>
+        <a href="https://qnfo.github.io/hardware-pathway/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/ultrametric-tree-universality">ultrametric-tree-universality</a></h3>
+    <p>Cross-domain tree universality explorer</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/ultrametric-tree-universality">GitHub</a>
+        <a href="https://qnfo.github.io/ultrametric-tree-universality/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/tree-and-shadow-viz">tree-and-shadow-viz</a></h3>
+    <p>Tree and Shadow phase diagram visualization</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/tree-and-shadow-viz">GitHub</a>
+        <a href="https://qnfo.github.io/tree-and-shadow-viz/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/ultrametric-game-of-life">ultrametric-game-of-life</a></h3>
+    <p>Conway's Game of Life on tree topologies</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/ultrametric-game-of-life">GitHub</a>
+        <a href="https://qnfo.github.io/ultrametric-game-of-life/">Live Demo</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/Physics-of-Rationalization">Physics-of-Rationalization</a></h3>
+    <p>Superdeterminism and the Illusion of Choice</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/Physics-of-Rationalization">GitHub</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/Beyond-Belief">Beyond-Belief</a></h3>
+    <p>Functional Anatomy of Human Ultimate Concern</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/Beyond-Belief">GitHub</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/zenodo-automation">zenodo-automation</a></h3>
+    <p>One-command Zenodo DOI registration pipeline</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/zenodo-automation">GitHub</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/nested-semantic-graph">nested-semantic-graph</a></h3>
+    <p>Language-neutral IR on Nested Semantic Trees</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/nested-semantic-graph">GitHub</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/license">license</a></h3>
+    <p>QNFO Content License Agreement</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/license">GitHub</a>
+    </div>
+</div>
+<div class="repo-card">
+    <h3><a href="https://github.com/QNFO/.github">.github</a></h3>
+    <p>Organization profile, legacy paper archive</p>
+    <div class="repo-links">
+        <a href="https://github.com/QNFO/.github">GitHub</a>
+    </div>
+</div>
+</div>
+</section>
+
+<footer>
+<p>QWAV -- Ultrametric Quantum Computing &amp; AI | <a href="https://github.com/QNFO/QWAV">QNFO/QWAV</a> | <a href="https://qnfo.github.io/QWAV/">Main Site</a></p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
Adds:\n- site/projects/index.html — listing all 15 QNFO project repos with descriptions and demo links\n- Updated main index.html nav with Papers and Projects links\n\nPart of GitHub-native migration completion.